### PR TITLE
Move the Go version used in workflows to a central location to make it easier to update

### DIFF
--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -12,9 +12,6 @@ on:
 
   workflow_dispatch: {}
 
-env:
-  GO_VERSION: "1.19"
-
 jobs:
   check-go-generate:
     runs-on: ubuntu-latest
@@ -22,6 +19,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
 
       - name: Install Go
         uses: actions/setup-go@v3

--- a/.github/workflows/constants.env
+++ b/.github/workflows/constants.env
@@ -1,0 +1,3 @@
+# Constants shared accross workflows
+
+GO_VERSION="1.20"

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -7,9 +7,6 @@ on:
 
   workflow_dispatch: {}
 
-env:
-  GO_VERSION: "1.19"
-
 jobs:
   lint-workflows:
     runs-on: ubuntu-latest
@@ -17,6 +14,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
 
       - name: Install Go
         uses: actions/setup-go@v3

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -10,9 +10,6 @@ on:
 
   workflow_dispatch: {}
 
-env:
-  GO_VERSION: "1.19"
-
 jobs:
   check-mod-tidy:
     runs-on: ubuntu-latest
@@ -20,6 +17,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
 
       - name: Install Go
         uses: actions/setup-go@v3
@@ -45,6 +47,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
+
       - name: Install Go
         uses: actions/setup-go@v3
         with:
@@ -65,6 +72,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
 
       - name: Install Go
         uses: actions/setup-go@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,6 @@ on:
     tags:
       - "v*.*.*"
 
-env:
-  GO_VERSION: "1.19"
-
 jobs:
   release-binary:
     runs-on: ubuntu-latest
@@ -23,6 +20,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
 
       - name: Checkout tags
         run: git fetch --force --tags

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,6 @@ on:
 
   workflow_dispatch: {}
 
-env:
-  GO_VERSION: "1.19"
-
 jobs:
   race-test:
     # required for nftables to work correctly
@@ -22,6 +19,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
 
       - name: Install Go
         uses: actions/setup-go@v3
@@ -42,6 +44,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
 
       - name: Install Go
         uses: actions/setup-go@v3
@@ -65,6 +72,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
 
       - name: Install Docker buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -12,9 +12,6 @@ on:
 
   workflow_dispatch: {}
 
-env:
-  GO_VERSION: "1.19"
-
 jobs:
   govulncheck:
     runs-on: ubuntu-latest
@@ -22,6 +19,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Export constant environmental variables
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .github/workflows/constants.env
 
       - name: Install Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
While here, also update to Go 1.20.