### PR TITLE
Refactor container -> container rule creation

### DIFF
--- a/config.go
+++ b/config.go
@@ -43,6 +43,8 @@ type ruleConfig struct {
 	Proto     protocol
 	Port      uint16
 	Verdict   verdict
+
+	skip bool
 }
 
 func (r ruleConfig) MarshalLogObject(enc zapcore.ObjectEncoder) error {
@@ -104,6 +106,10 @@ func (a addrOrRange) MarshalText() ([]byte, error) {
 	return a.addrRange.MarshalText()
 }
 
+func (a addrOrRange) MarshalBinary() ([]byte, error) {
+	return a.MarshalText()
+}
+
 func (a *addrOrRange) UnmarshalText(text []byte) error {
 	if bytes.ContainsRune(text, '/') {
 		prefix := new(netip.Prefix)
@@ -117,6 +123,10 @@ func (a *addrOrRange) UnmarshalText(text []byte) error {
 		return a.addrRange.UnmarshalText(text)
 	}
 	return a.addr.UnmarshalText(text)
+}
+
+func (a *addrOrRange) UnmarshalBinary(data []byte) error {
+	return a.UnmarshalText(data)
 }
 
 func (a addrOrRange) MarshalLogObject(enc zapcore.ObjectEncoder) error {

--- a/database/models.go
+++ b/database/models.go
@@ -25,3 +25,10 @@ type EstContainer struct {
 	SrcContainerID string
 	DstContainerID string
 }
+
+type WaitingContainerRule struct {
+	SrcContainerID   string
+	DstContainerName string
+	Rule             []byte
+	Active           bool
+}

--- a/database/query.sql
+++ b/database/query.sql
@@ -1,3 +1,11 @@
+-- name: ActivateWaitingContainerRules :exec
+UPDATE
+	waiting_container_rules
+SET
+	active = TRUE
+WHERE
+	dst_container_name = ?;
+
 -- name: AddContainer :exec
 INSERT INTO
 	containers(id, name)
@@ -34,6 +42,23 @@ VALUES
 		?
 	);
 
+-- name: AddWaitingContainerRule :exec
+INSERT INTO
+	waiting_container_rules
+	(
+		src_container_id,
+		dst_container_name,
+		rule,
+		active
+	)
+VALUES
+	(
+		?,
+		?,
+		?,
+		TRUE
+	);
+
 -- name: ContainerExists :one
 SELECT
 	EXISTS (
@@ -66,6 +91,20 @@ WHERE
 -- name: DeleteEstContainers :exec
 DELETE FROM
 	est_containers
+WHERE
+	src_container_id = ?;
+
+-- name: DeactivateWaitingContainerRules :exec
+UPDATE
+	waiting_container_rules
+SET
+	active = FALSE
+WHERE
+	dst_container_name = ?;
+
+-- name: DeleteWaitingContainerRules :exec
+DELETE FROM
+	waiting_container_rules
 WHERE
 	src_container_id = ?;
 
@@ -125,3 +164,18 @@ ON
 	c.id = e.dst_container_id
 WHERE
 	e.src_container_id = ?;
+
+-- name: GetWaitingContainerRules :many
+SELECT
+	w.src_container_id,
+	c.name,
+	w.rule
+FROM
+	waiting_container_rules w
+JOIN
+	containers c
+ON
+	c.id = w.src_container_id
+WHERE
+	w.dst_container_name = ? AND
+	w.active = TRUE;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -26,3 +26,13 @@ CREATE TABLE est_containers (
   FOREIGN KEY(src_container_id) REFERENCES containers(id),
   FOREIGN KEY(dst_container_id) REFERENCES containers(id)
 );
+
+CREATE TABLE waiting_container_rules (
+  src_container_id   TEXT    NOT NULL,
+  dst_container_name TEXT    NOT NULL,
+  rule               BLOB    NOT NULL,
+  active             BOOLEAN NOT NULL,
+
+  PRIMARY KEY(src_container_id, dst_container_name, rule),
+  FOREIGN KEY (src_container_id) REFERENCES containers(id)
+);

--- a/mock-nftables.go
+++ b/mock-nftables.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/nftables"
 	"go.uber.org/zap"
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 )
 
@@ -55,6 +56,14 @@ func newMockFirewall(logger *zap.Logger) *mockFirewall {
 		logger: logger.Sugar(),
 		tables: make(map[string]table),
 		chains: make(map[string]chain),
+	}
+}
+
+func (m *mockFirewall) clone() *mockFirewall {
+	return &mockFirewall{
+		logger: m.logger,
+		tables: maps.Clone(m.tables),
+		chains: maps.Clone(m.chains),
 	}
 }
 
@@ -182,7 +191,7 @@ func (m *mockFirewall) SetDeleteElements(s *nftables.Set, vals []nftables.SetEle
 			m.logger.Errorf("set element with key %v not found", v.Key)
 			m.flushErr = syscall.ENOENT
 		}
-		elements = slices.Delete(elements, i, i)
+		elements = slices.Delete(elements, i, i+1)
 	}
 	t.sets[s.Name] = elements
 	m.tables[s.Table.Name] = t
@@ -221,7 +230,7 @@ func (m *mockFirewall) DelRule(r *nftables.Rule) error {
 		return nil
 	}
 
-	c.rules = slices.Delete(c.rules, i, i)
+	c.rules = slices.Delete(c.rules, i, i+1)
 	m.chains[r.Chain.Name] = c
 
 	return nil

--- a/testdata/docker-compose.yml
+++ b/testdata/docker-compose.yml
@@ -2,8 +2,6 @@ version: "3"
 services:
   client:
     command: "80"
-    depends_on:
-      - server
     image: ghcr.io/capnspacehook/eavesdropper
     labels:
       whalewall.enabled: true
@@ -22,12 +20,14 @@ services:
           - network: default
             container: server
             proto: tcp
-            port: 9001
+            port: 756
     ports:
       - "8080:80"
 
   server:
-    command: "80 9001"
+    command: "80 756 9001"
+    depends_on:
+      - client
     image: ghcr.io/capnspacehook/eavesdropper
     labels:
       whalewall.enabled: true


### PR DESCRIPTION
Previously when processing a rule to allow access to another container, whalewall would pause processing of the current container and process all other started containers until the container specified in the original rule was processed or a timeout was hit. nftable rules need to be added to both containers' chains in this case. This was problematic for environments with unpredictable container ordering or slow start times.

Instead, when processing a rule involving another container, add an entry to the database requesting creation of these rules when the other container is processed. When the other container is processed, whalewall will lookup rule requests and create the rules for the original container then.