### PR TITLE
Flush nftables changes in small batches instead of all at once

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,34 @@
+package whalewall
+
+import (
+	"context"
+	"errors"
+	"syscall"
+	"time"
+)
+
+// withTimeout runs f with a timeout derived from [context.WithTimeout].
+// Using withTimeout guarantees that:
+//
+//   - ctx is only shadowed in withTimeout's scope
+//   - The child context will have it's resources released immediately
+//     after f returns
+//
+// The main goal of withTimeout is to prevent shadowing ctx with a
+// context with a timeout, having that timeout expire and the next call
+// that uses ctx immediately fail.
+func withTimeout[T, E any](ctx context.Context, timeout time.Duration, f func(ctx context.Context) (T, E)) (T, E) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return f(ctx)
+}
+
+// ignoringENOENT calls f and discards the error if any error in the error
+// tree matches [syscall.ENOENT].
+func ignoringENOENT(f func() error) error {
+	err := f()
+	if err == nil || (err != nil && errors.Is(err, syscall.ENOENT)) {
+		return nil
+	}
+	return err
+}

--- a/wrap.go
+++ b/wrap.go
@@ -37,19 +37,3 @@ func (w *wrappedDockerClient) ContainerInspect(ctx context.Context, containerID 
 		return w.dockerClient.ContainerInspect(ctx, containerID)
 	})
 }
-
-// withTimeout runs f with a timeout derived from [context.WithTimeout].
-// Using withTimeout guarantees that:
-//
-//   - ctx is only shadowed in withTimeout's scope
-//   - The child context will have it's resources released immediately
-//     after f returns
-//
-// The main goal of withTimeout is to prevent shadowing ctx with a
-// context with a timeout, having that timeout expire and the next call
-// that uses ctx immediately fail.
-func withTimeout[T, E any](ctx context.Context, timeout time.Duration, f func(ctx context.Context) (T, E)) (T, E) {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	return f(ctx)
-}


### PR DESCRIPTION
This will make future debugging easier, as now an nftables error will be related to a specific set of nftables operations, instead of all the nftables operations for a container. Also log errors when creating non-essential rules and continue instead of stopping rule creation entirely.

Updates #71.