### PR TITLE
Recreate missing nftables rules for containers on startup

### DIFF
--- a/database/query.sql
+++ b/database/query.sql
@@ -57,7 +57,8 @@ VALUES
 		?,
 		?,
 		TRUE
-	);
+	)
+ON CONFLICT(src_container_id, dst_container_name, rule) DO NOTHING;
 
 -- name: ContainerExists :one
 SELECT

--- a/database/query.sql.go
+++ b/database/query.sql.go
@@ -119,6 +119,7 @@ VALUES
 		?,
 		TRUE
 	)
+ON CONFLICT(src_container_id, dst_container_name, rule) DO NOTHING
 `
 
 type AddWaitingContainerRuleParams struct {


### PR DESCRIPTION
When whalewall first starts, checks are made to ensure that containers that are no longer running have their rules removed, and containers that were started while whalewall wasn't running have their rules created. If whalewall previously created rules for a container, whalewall was stopped and the container's rules were removed, whalewall would see that the running container is in the database and do nothing once whalewall was started again.

Now whalewall will add any missing rules for known containers on startup. In the future this may be done periodically.