### PR TITLE
Set explicit timeout for golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,3 +59,6 @@ linters-settings:
     rules:
       - name: blank-imports
         disabled: true
+
+run:
+  timeout: 10m


### PR DESCRIPTION
The default timeout is 1 minute which was causing workflow runs to fail sporadically.